### PR TITLE
修复了致谢页后面空白页页眉错误的问题

### DIFF
--- a/seu-engineering/seuthesix.cls
+++ b/seu-engineering/seuthesix.cls
@@ -659,7 +659,7 @@ chapter/titleformat=\large\heiti
 \cleardoublepage
 \phantomsection
 \addcontentsline{toc}{chapter}{致 谢}
-\chapter*{致 谢}
+\chapter*{致 谢\markboth{致 谢}{}}
 }
 
 \newcommand{\thesisbib}[1]{%

--- a/seu-master/seuthesix.cls
+++ b/seu-master/seuthesix.cls
@@ -659,7 +659,7 @@ chapter/titleformat=\large\heiti
 \cleardoublepage
 \phantomsection
 \addcontentsline{toc}{chapter}{致 谢}
-\chapter*{致 谢}
+\chapter*{致 谢\markboth{致 谢}{}}
 }
 
 \newcommand{\thesisbib}[1]{%

--- a/seu-phd/seuthesix.cls
+++ b/seu-phd/seuthesix.cls
@@ -659,7 +659,7 @@ chapter/titleformat=\large\heiti
 \cleardoublepage
 \phantomsection
 \addcontentsline{toc}{chapter}{致 谢}
-\chapter*{致 谢}
+\chapter*{致 谢\markboth{致 谢}{}}
 }
 
 \newcommand{\thesisbib}[1]{%


### PR DESCRIPTION
由于致谢页不需要章节号，因此采用chapter*{致谢}创建该章节。但是此时的\leftmark不会更新为“致谢”，导致页眉内容的错误。本修改中，在使用chapter*{致谢}的同时，强制设定\leftmark内容为“致谢”，从而保证页眉内容正确。